### PR TITLE
linkify tweets better with the new linkifyTweet helper or the helpers…

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,8 +131,33 @@ function Construct(options, callback) {
   self._apos.addLocal('linkifyTweetUrls', function(text) {
     return text.replace(/https?\:\/\/\S+/g, function(url) {
       var urlSansPeriod = url.replace(/\.$/, '');
+      if (url.match(/…$/)) {
+        // Useless URL
+        return '';
+      }
       return '<a href="' + urlSansPeriod + '" target="blank">' + url + '</a>';
     });
+  });
+
+  self._apos.addLocal('linkifyTweetMentions', function(text) {
+    return text.replace(/\@[^\s\,\.\!\?\:\/]+/g, function(user) {
+      var result = '<a class="apos-twitter-mention" href="http://twitter.com/' + self._apos.escapeHtml(user.substr(1)) + '" target="blank">' + user + '</a>';
+      return result;
+    });
+  });
+
+  self._apos.addLocal('linkifyTweetHashtags', function(text) {
+    return text.replace(/\#[^\s\,\.\!\?\:\/]+/g, function(hashtag) {
+      return '<a class="apos-twitter-hashtag" href="http://twitter.com/' + self._apos.escapeHtml(hashtag) + '" target="blank">' + hashtag + '</a>';
+    });
+  });
+
+  self._apos.addLocal('linkifyTweet', function(text) {
+    return self._apos._aposLocals.linkifyTweetMentions(
+      self._apos._aposLocals.linkifyTweetHashtags(
+        self._apos._aposLocals.linkifyTweetUrls(text)
+      )
+    );
   });
 
   self._apos.addLocal('getRelativeTime', function(datetime, noSuffix) {

--- a/views/widget.html
+++ b/views/widget.html
@@ -5,11 +5,11 @@
     <li class="apos-tweet">
       <span class="apos-tweet-profile">
         <span class="apos-tweet-profile-image"></span>
-        <span class="apos-tweet-username">@{{ tweet.user.screen_name | e }}</span>
+        <span class="apos-tweet-username"><a href="https://twitter.com/{{ tweet.user.screen_name | e }}">@{{ tweet.user.screen_name | e }}</a></span>
         <span class="apos-tweet-date">{{ tweet.created_at | date('MM/DD/YYYY h:mma') }}</span>
       </span>
 
-      <span class="apos-tweet-text">{{ linkifyTweetUrls(tweet.text) }}</span>
+      <span class="apos-tweet-text">{{ linkifyTweet(tweet.text) }}</span>
     </li>
   {%- endfor -%}
 </ul>


### PR DESCRIPTION
… it calls for you. Mentions and hashtags get linked properly, and URLs that end in the ellipsis character are discarded entirely (as they enver work).
